### PR TITLE
readxl is installed with Tidyverse, but not loaded with it

### DIFF
--- a/table.Rmd
+++ b/table.Rmd
@@ -123,7 +123,7 @@ exceldata %>%
   flextable::border_outer()
 ```
 
-To load excel data from your own computer,  you can use the `read_excel` function from the `readxl` package (which is part of the tidyverse and thus does not need to be loaded separately (we have already loaded the `tidyverse`  above, so we do not need to do this again here). 
+To load excel data from your own computer, you can use the `read_excel` function from the `readxl` package (which is part of the tidyverse and thus does not need to be installed separately.
 
 ***
 


### PR DESCRIPTION
Just clarifying that readxl is installed with the tidyverse but using `library(tidyverse)` only loads the 8 core packages (and not readxl).