### PR TITLE
Fix the missing call for the model fitting table

### DIFF
--- a/regression.html
+++ b/regression.html
@@ -4700,7 +4700,8 @@ m9.m6 &lt;- anova(m9.glmer, m6.glmer, test = &quot;Chi&quot;)
 mdlcmp &lt;- list(m1.m0, m2.m1, m3.m1, m4.m3, m5.m4, m6.m4, m7.m6, m8.m6, m9.m6)
 # summary table for model fitting
 mdlft &lt;- mdl.fttng.swsu(mdlcmp)
-mdlft &lt;- mdlft[,-2]</code></pre>
+mdlft &lt;- mdlft[,-2]
+mdlft</code></pre>
 <template id="890ccba6-5f36-4c3a-b977-12bb2df3e7f2"><style>
 .tabwid table{
   border-spacing:0px !important;


### PR DESCRIPTION
Not sure was it intentional or not but the call for the model fitting table from ModelFittingSummarySWSU.r function was missing at end of the code snippet at line 4704. So it was added. 

Btw, thank you for the amazing resources! Really helps! 💯 

Cheers
IsilB.